### PR TITLE
Use adts which requires adt.rb

### DIFF
--- a/lib/adts.rb
+++ b/lib/adts.rb
@@ -1,0 +1,1 @@
+require 'adt'

--- a/spec/adt_spec.rb
+++ b/spec/adt_spec.rb
@@ -1,5 +1,5 @@
 require 'rspec'
-require 'adt'
+require 'adts'
 
 Shape = ADT do
   Void() |


### PR DESCRIPTION
In the Readme as example following is used:

``` ruby
require 'adts'
```

This would lead to an error because no `adts.rb` is available through the adts gem.
In this PR I added a `adts.rb` file which requires `adt.rb` 
