### PR TITLE
Allow arguments of types inherited from the declared types

### DIFF
--- a/lib/adt/constructor.rb
+++ b/lib/adt/constructor.rb
@@ -11,8 +11,10 @@ module ADT
         attr_reader #{keys.map { |n| ":#{n}" }.join(', ')}
 
         def initialize(#{keys.join(", ")})
-          types = [#{keys.join(", ")}].map(&:class)
-          raise TypeError, 'Types mismatch: given ' + types.join(', ') + ', expected #{types.join(", ")}' unless types == [#{types.join(", ")}]
+          arg_types = [#{keys.join(", ")}].map(&:class)
+          unless arg_types.zip([#{types.join(", ")}]).all? { |arg_type, type| arg_type <= type }
+            raise TypeError, 'Types mismatch: given ' + arg_types.join(', ') + ', expected #{types.join(", ")}'
+          end
           #{keys.empty? ? "" : keys.map{ |n| "@#{n}" }.join(',') + " = " + keys.join(", ")}
         end
 

--- a/spec/adt_spec.rb
+++ b/spec/adt_spec.rb
@@ -4,7 +4,7 @@ require 'adt'
 Shape = ADT do
   Void() |
   Square(width: Fixnum) |
-  Rectangle(width: Fixnum, height: Fixnum) |
+  Rectangle(width: Numeric, height: Numeric) |
   Circle(radius: Fixnum) {
     def area
       Math::PI * radius * radius
@@ -20,6 +20,11 @@ describe ADT do
   it 'typechecks the non-nullary constructors'do
     expect { Shape::Square(23) }.to_not raise_exception
     expect { Shape::Square("foo") }.to raise_exception(TypeError)
+  end
+
+  it 'allows inherited types' do
+    expect { Shape::Rectangle(23, 45.1) }.to_not raise_exception
+    expect { Shape::Rectangle("foo", "bar") }.to raise_exception(TypeError)
   end
 
   it 'implements equality by type and value' do


### PR DESCRIPTION
Allow arguments of types inherited from the declared types.

For example, if the ADT is:

```
Shape = ADT do
  Rectangle(width: Numeric, height: Numeric)
end
```

then allow the Square::Rectangle constructor to accept any Numeric subclass, such as Fixnum (42), Float (42.1), Bignum (100000000000000000000000000000), Rational ( 3/2r ) and so on.
